### PR TITLE
Add support for for different modes of display in formatNumber

### DIFF
--- a/helpers/formatNumber.js
+++ b/helpers/formatNumber.js
@@ -1,4 +1,13 @@
-function formatNumber(num, shortHand = false, decimalPlaces = 2) {
+function formatNumber(num, shortHand = false, decimalPlaces = 2, display = 0) { 
+    /*
+    ok this commit shouldn't be pulled till you add a settings command
+    you also need to add this new flag to. every instance of formatNumber used..
+    new flag alert!! display flag, this will do a few things
+    if display is 0, it will display the numbers as how they are currently. so using shortened prefixes till e100
+    if display is 1, it will display the numbers with the full name, until e100.
+    if display is 2, it will just use scientific notation for all numbers
+    */
+    
     if (num === null || num === undefined) return '0'; // handle null or undefined values
     if (!isFinite(num)) return num === Infinity ? 'Infinity' : 'NaN'; // handle special values
 
@@ -9,38 +18,50 @@ function formatNumber(num, shortHand = false, decimalPlaces = 2) {
                       'Vg', 'Uvg', 'Dvg', 'Trv', 'Qtv', 'Qiv', 'Sxv', 'Spv', 'Ocv', // 10^87
                       'Ndv', 'Tg', 'Utg', 'Dtg'];  // 10^99
 
-    //get magnitude
+    const fullSuffixes = ['', 'Thousand', 'Million', 'Billion', 'Trillion', 'Quadrillion', 'Quintillion', // 10^18
+                          'Sextillion', 'Septillion', 'Octillion', 'Nonillion', // 10^30
+                          'Decillion', 'Undecillion', 'Duodecillion', 'Tredecillion', // 10^42
+                          'Quattuordecillion', 'Quindecillion', 'Sexdecillion', 'Septendecillion', 'Octodecillion', 'Novemdecillion', // 10^60
+                          'Vigintillion', 'Unvigintillion', 'Duovigintillion', 'Trevigintillion', 'Quattuorvigintillion', // 10^75
+                          'Quinvigintillion', 'Sexvigintillion', 'Septenvigintillion', 'Octovigintillion', // 10^87
+                          'Novemvigintillion', 'Trigintillion', 'Untrigintillion', 'Duotrigintillion'];  // 10^99
+
+    // get magnitude
     const magnitude = Math.floor(Math.log10(num));
+    const suffixIndex = Math.floor(magnitude / 3);
 
-    //if number is above e100 then just use exponent
-    if (magnitude >= 100) {
-        return num.toExponential(decimalPlaces);
+    // if display mode is 2 or number is above e100 then just use exponent
+    if (display === 2 || magnitude >= 100) {
+        //get rid of the + because it looks dumb
+        const parts = num.toExponential(decimalPlaces).split('e');
+        const exponent = parts[1].replace('+', '');
+        return `${parts[0]}e${exponent}`;
     }
 
-    if (numStr.includes("e")) { 
-        const suffixIndex = Math.floor(magnitude / 3);
-        const baseNum = (num / Math.pow(10, suffixIndex * 3)).toFixed(decimalPlaces);
-        return baseNum + (suffixes[suffixIndex] || '');
-    }
+    if (numStr.length < 4) return numStr; // if less than 4 digits, return as is
 
-    if (numStr.length < 4) return numStr;
-
-    const suffixIndex = Math.floor((numStr.length - 1) / 3);
     if (decimalPlaces >= suffixIndex * 3) {
         decimalPlaces = suffixIndex * 3;
         shortHand = false;
     }
 
     if (!shortHand) {
-        return numStr.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        return numStr.replace(/\B(?=(\d{3})+(?!\d))/g, ','); //return with commas if not shorthand
     }
 
+    //format base number, before adding suffix
     const baseNum = (
         Math.ceil((num * (10 ** (decimalPlaces + 1)) / Math.pow(10, suffixIndex * 3))) /
         (10 ** (decimalPlaces + 1))
     ).toFixed(decimalPlaces);
 
-    return baseNum + suffixes[suffixIndex];
+    //if display is 1, use full name instead of shortened suffix
+    if (display === 1) {
+        return baseNum + ' ' + (fullSuffixes[suffixIndex] || '');
+    }
+
+    // default to short suffix (display === 0)
+    return baseNum + (suffixes[suffixIndex] || '');
 }
 
 module.exports = formatNumber;

--- a/helpers/formatNumber.js
+++ b/helpers/formatNumber.js
@@ -14,9 +14,9 @@ function formatNumber(num, shortHand = false, decimalPlaces = 2, display = 0) {
     const numStr = num.toString();
 
     const suffixes = ['', 'K', 'M', 'B', 'T', 'Qa', 'Qi', 'Sx', 'Sp', 'Oc', 'No', // 10^30
-                      'Dc', 'Ud', 'Dd', 'Td', 'Qtd', 'Qd', 'Sxd', 'Spd', 'Od', 'Nd', // 10^60
-                      'Vg', 'Uvg', 'Dvg', 'Trv', 'Qtv', 'Qiv', 'Sxv', 'Spv', 'Ocv', // 10^87
-                      'Ndv', 'Tg', 'Utg', 'Dtg'];  // 10^99
+                      'Dc', 'Udc', 'Ddc', 'Tdc', 'Qadc', 'Qidc', 'Sxdc', 'Spdc', 'Ocdc', 'Nmdc', // 10^60
+                      'Vg', 'Uvg', 'Dvg', 'Tvg', 'Qavg', 'Qivg', 'Sxvg', 'Spvg', 'Ovg', // 10^87
+                      'Nvg', 'Tg', 'Utg', 'Dtg'];  // 10^99
 
     const fullSuffixes = ['', 'Thousand', 'Million', 'Billion', 'Trillion', 'Quadrillion', 'Quintillion', // 10^18
                           'Sextillion', 'Septillion', 'Octillion', 'Nonillion', // 10^30


### PR DESCRIPTION
This adds a new `display` option to the formatNumber function:
- 0 = use short suffixes (default, e.g. 61.492 Oc)
- 1 = use full name (e.g., "61.492 Octillion")
- 2 = use scientific notation (e.g., "6.149e28")

This commit isn't ready to be pulled immediately, there should be the /settings command to configure this. It would work, because it defaults to 0, so it wouldn't change anything, so you can if you want, but ideally the settings command would be done so this is actually somewhat useful.

if you want, you can change some uses of the formatnumber function to use the new method so the formatting is nicer? like, as an example, you could change leaderboard to use the full name instead of the shortened version. Just an example, not saying you should.